### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -5,6 +5,7 @@ on:
       - master
   workflow_dispatch:
   
+permissions: {}
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+' # semver stable
       - 'v[0-9]+.[0-9]+.[0-9]+-*' # semver with prerelease suffix
+permissions: {}
 jobs:
   metadata:
     runs-on: ubuntu-latest
@@ -14,7 +15,7 @@ jobs:
       release-exist: ${{ steps.metadata.outputs.release_exist }}
       is-stable-release: ${{ steps.metadata.outputs.is_stable_release }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Metadata
         id: metadata
         env:
@@ -48,23 +49,23 @@ jobs:
     env:
       CONTAINER_REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: "${{ env.CONTAINER_REGISTRY }}/equinor/radix/image-builder"
           tags: |
             type=raw,value=${{ needs.metadata.outputs.version }}
             type=raw,value=latest,enable=${{ needs.metadata.outputs.is-stable-release }}
       - name: Build and push container images
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,22 +49,22 @@ jobs:
       CONTAINER_REGISTRY: ghcr.io
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: "${{ env.CONTAINER_REGISTRY }}/equinor/radix/image-builder"
           tags: |
             type=raw,value=${{ needs.metadata.outputs.version }}
             type=raw,value=latest,enable=${{ needs.metadata.outputs.is-stable-release }}
       - name: Build and push container images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       release-exist: ${{ steps.metadata.outputs.release_exist }}
       is-stable-release: ${{ steps.metadata.outputs.is_stable_release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Metadata
         id: metadata
         env:
@@ -48,7 +48,7 @@ jobs:
     env:
       CONTAINER_REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
     - name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
       with:
         context: .
         push: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
     - master
+permissions: {}
 jobs:
   build:
     name: pull-request-check
@@ -10,11 +11,11 @@ jobs:
     permissions: 
       contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
     - name: Build Docker image
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .
         push: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions: 
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build Docker image

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -7,6 +7,7 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prepare-release-pr:
     name: Prepare release pull request
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Update deprecated GitHub Actions to versions compatible with Node.js 24.\n\n- Update actions/checkout to v6\n- Update radix-reusable-workflows to v1.1.0\n\nNode.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026.